### PR TITLE
Make - optional for poland postal codes

### DIFF
--- a/formats/PL.json
+++ b/formats/PL.json
@@ -1,14 +1,14 @@
 {
   "Description": "PL : 99-999",
   "RedundantCharacters": " ",
-  "ValidationRegex": "^[0-9]{2}-[0-9]{3}$",
+  "ValidationRegex": "^[0-9]{2}(-)?[0-9]{3}$",
   "TestData": {
     "Valid": [
       "44-100 ",
-      "44-100"
+      "44-100",
+      "44100"
     ],
     "Invalid": [
-      "44100",
       "44f00",
       "e4410",
       "44-100d",


### PR DESCRIPTION
We don't need this character to be there, we can add it back to all polish postal codes when normalizing