### PR TITLE
Include 6 digit zip codes for Cambodia

### DIFF
--- a/formats-web.js
+++ b/formats-web.js
@@ -33,6 +33,7 @@ formats["IE.json"] = require("./formats/IE.json");
 formats["IM.json"] = require("./formats/IM.json");
 formats["IO.json"] = require("./formats/IO.json");
 formats["JE.json"] = require("./formats/JE.json");
+formats["KH.json"] = require("./formats/KH.json");
 formats["KY.json"] = require("./formats/KY.json");
 formats["LB.json"] = require("./formats/LB.json");
 formats["LC.json"] = require("./formats/LC.json");

--- a/formats/KH.json
+++ b/formats/KH.json
@@ -1,0 +1,18 @@
+{
+  "Description": "KH",
+  "RedundantCharacters": " -",
+  "ValidationRegex": "^[0-9]{5,6}$",
+  "TestData": {
+    "Valid": [
+      "12345",
+      "56785",
+      "123456"
+    ],
+    "Invalid": [
+      "1234",
+      "1234567",
+      "1233s",
+      "123x3"
+    ]
+  }
+}

--- a/generated/postal-codes-alpha2.json
+++ b/generated/postal-codes-alpha2.json
@@ -249,7 +249,7 @@
     },
     "KH": {
         "countryName": "Cambodia",
-        "postalCodeFormat": "5Digits.json",
+        "postalCodeFormat": "KH.json",
         "alpha2": "KH",
         "alpha3": "KHM",
         "numeric3": "116"

--- a/generated/postal-codes-alpha3.json
+++ b/generated/postal-codes-alpha3.json
@@ -249,7 +249,7 @@
     },
     "KHM": {
         "countryName": "Cambodia",
-        "postalCodeFormat": "5Digits.json",
+        "postalCodeFormat": "KH.json",
         "alpha2": "KH",
         "alpha3": "KHM",
         "numeric3": "116"

--- a/mappings/alpha2-to-formats.json
+++ b/mappings/alpha2-to-formats.json
@@ -79,7 +79,6 @@
     "IT",
     "JO",
     "KE",
-    "KH",
     "KR",
     "KW",
     "LA",
@@ -208,6 +207,9 @@
   ],
   "JE.json": [
     "JE"
+  ],
+  "KH.json": [
+    "KH"
   ],
   "KY.json": [
     "KY"


### PR DESCRIPTION
Update Cambodia zip code validation to allow both 5 digit and the newer 6 digit formats. Cambodia migrated to 6 digit zip codes in 2018 according to this [site](https://khm.postcodebase.com/).